### PR TITLE
Fix messages create bug

### DIFF
--- a/app/assets/javascripts/messages.js
+++ b/app/assets/javascripts/messages.js
@@ -1,6 +1,6 @@
 $(document).on('turbolinks:load', function() {
   function buildHTML(message) {
-    const image = message.image.url ? `<img src="${message.image.url}">` : "" ;
+    const image = message.image ? `<img src="${message.image}">` : "" ;
     const html = `<div class="message" data-message_id="${message.id}">
                     <div class="message__upper-info">
                       <p class="message__upper-info__talker">${message.user_name}</p>
@@ -34,19 +34,23 @@ $(document).on('turbolinks:load', function() {
       contentType: false
     })
     .done(function(message) {
-      $('#new_message')[0].reset();
-      $('.messages').append(buildHTML(message));
-      $('.messages').animate({
-        scrollTop: $('.messages')[0].scrollHeight
-      }, 200);
+      if (message.content == "" && message.image == null) {
+        alert('メッセージを入力して下さい');
+      } else {
+        $('#new_message')[0].reset();
+        $('.messages').append(buildHTML(message));
+        $('.messages').animate({
+          scrollTop: $('.messages')[0].scrollHeight
+        }, 200);
+
+      }
     })
     .fail(function() {
       alert("通信に失敗しました");
-    });
-
-    setTimeout(function() {
+    })
+    .always(function() {
       $(".submit-btn").prop('disabled', false)
-    }, 1000);
+    });
   });
 
   // 自動更新

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -20,10 +20,6 @@ class MessagesController < ApplicationController
         format.html { redirect_to group_messages_path, notice: "メッセージが送信されました" }
         format.json
       end
-    else
-      @messages = @group.messages.includes(:user)
-      flash.now[:alert] = 'メッセージを入力して下さい'
-      render :index
     end
   end
 

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -1,5 +1,5 @@
 json.id         @message.id
 json.content    @message.content
-json.image      @message.image
+json.image      @message.image.url
 json.created_at @message.created_at.to_s
 json.user_name  @message.user.name

--- a/app/views/messages/index.json.jbuilder
+++ b/app/views/messages/index.json.jbuilder
@@ -1,7 +1,7 @@
 json.array! @new_messages do |message|
   json.id         message.id
   json.content    message.content
-  json.image      message.image
+  json.image      message.image.url
   json.created_at message.created_at.to_s
   json.user_name  message.user.name
 end


### PR DESCRIPTION
# WHAT
メッセージも画像も無い場合のエラーハンドリングをJSで行うように変更
JSでmessage.image.urlを取得するのではなく
jbuilderでurlまで取得してmessage.imageに渡すように変更